### PR TITLE
Fix removeChangeListener argument

### DIFF
--- a/app/components/Tracks.js
+++ b/app/components/Tracks.js
@@ -7,12 +7,13 @@ export default class Tracks extends React.Component {
     this.state = {
       tracks: TrackStore.getAll()
     }
+    this._onChange = this._onChange.bind(this)
   }
   componentDidMount() {
-    TrackStore.addChangeListener(this._onChange.bind(this));
+    TrackStore.addChangeListener(this._onChange);
   }
   componentWillUnmount() {
-    TrackStore.removeChangeListener(this._onChange.bind(this));
+    TrackStore.removeChangeListener(this._onChange);
   }
   _onChange() {
     this.setState({ tracks: TrackStore.getAll() });


### PR DESCRIPTION
Function.prototype.bind() returns another function everytime to call.
So Tracks wil continue to listen TrackStore even after unmount.